### PR TITLE
Feature/add support new devices from xcode 13

### DIFF
--- a/Sources/PreviewDevice/Device.swift
+++ b/Sources/PreviewDevice/Device.swift
@@ -33,6 +33,10 @@ public enum Device: String {
     case iphone12 = "iPhone 12"
     case iphone12Pro = "iPhone 12 Pro"
     case iphone12ProMax = "iPhone 12 Pro Max"
+    case iphone13Mini = "iPhone 13 mini"
+    case iphone13 = "iPhone 13"
+    case iphone13Pro = "iPhone 13 Pro"
+    case iphone13ProMax = "iPhone 13 Pro Max"
     
     // MARK: - iPad
     
@@ -42,6 +46,8 @@ public enum Device: String {
     case ipadMini2 = "iPad mini 2"
     case ipadMini3 = "iPad mini 3"
     case ipadMini4 = "iPad mini 4"
+    case ipadMini5 = "iPad mini (5th generation)"
+    case ipadMini6 = "iPad mini (6th generation)"
     case ipadAir2 = "iPad Air 2"
     case ipadPro9_7inch = "iPad Pro (9.7-inch)"
     case ipadPro12_9inch = "iPad Pro (12.9-inch)"
@@ -50,13 +56,13 @@ public enum Device: String {
     case ipadPro10_5inch = "iPad Pro (10.5-inch)"
     case ipad_6Gen = "iPad (6th generation)"
     case ipad_7Gen = "iPad (7th generation)"
+    case ipad_8Gen = "iPad (8th generation)"
+    case ipad_9Gen = "iPad (9th generation)"
     case ipadPro11inch_1Gen = "iPad Pro (11-inch) (1st generation)"
     case ipadPro12_9inch_3Gen = "iPad Pro (12.9-inch) (3rd generation)"
     case ipadPro11inch_2Gen = "iPad Pro (11-inch) (2nd generation)"
     case ipadPro12_9inch_4Gen = "iPad Pro (12.9-inch) (4th generation)"
-    case ipadMini_5Gen = "iPad mini (5th generation)"
     case ipadAir_3Gen = "iPad Air (3rd generation)"
-    case ipad_8Gen = "iPad (8th generation)"
     case ipadAir_4Gen = "iPad Air (4th generation)"
     
     // MARK: - iPod
@@ -90,4 +96,6 @@ public enum Device: String {
     case watchSE_44mm = "Apple Watch SE - 44mm"
     case watchSeries6_40mm = "Apple Watch Series 6 - 40mm"
     case watchSeries6_44mm = "Apple Watch Series 6 - 44mm"
+    case watchSeries7_41mm = "Apple Watch Series 7 - 41mm"
+    case watchSeries7_45mm = "Apple Watch Series 7 - 45mm"
 }

--- a/Tests/PreviewDeviceTests/DeviceIpadTests.swift
+++ b/Tests/PreviewDeviceTests/DeviceIpadTests.swift
@@ -58,8 +58,8 @@ final class DeviceIpadTests: XCTestCase {
         XCTAssertEqual(iphone.rawValue, "iPad mini 4")
     }
     
-    func testIpadMini_5GenHasCorretName() {
-        let iphone: Device = .ipadMini_5Gen
+    func testIpadMini5GHasCorretName() {
+        let iphone: Device = .ipadMini5
         XCTAssertEqual(iphone.rawValue, "iPad mini (5th generation)")
     }
     

--- a/Tests/PreviewDeviceTests/DeviceIpadTests.swift
+++ b/Tests/PreviewDeviceTests/DeviceIpadTests.swift
@@ -63,6 +63,11 @@ final class DeviceIpadTests: XCTestCase {
         XCTAssertEqual(iphone.rawValue, "iPad mini (5th generation)")
     }
     
+    func testIpadMini6GHasCorretName() {
+        let iphone: Device = .ipadMini6
+        XCTAssertEqual(iphone.rawValue, "iPad mini (6th generation)")
+    }
+    
     // MARK: - Ipad 5 Gen, 6 Gen, 7 Gen, 8 Gen
     
     func testIpad_5GenHasCorretName() {
@@ -83,6 +88,11 @@ final class DeviceIpadTests: XCTestCase {
     func testIpad_8GenHasCorretName() {
         let iphone: Device = .ipad_8Gen
         XCTAssertEqual(iphone.rawValue, "iPad (8th generation)")
+    }
+    
+    func testIpad_9GenHasCorretName() {
+        let iphone: Device = .ipad_9Gen
+        XCTAssertEqual(iphone.rawValue, "iPad (9th generation)")
     }
     
     // MARK: - Ipad Pro

--- a/Tests/PreviewDeviceTests/DeviceIphoneTests.swift
+++ b/Tests/PreviewDeviceTests/DeviceIphoneTests.swift
@@ -129,4 +129,26 @@ final class DeviceIphoneTests: XCTestCase {
         let iphone: Device = .iphone12ProMax
         XCTAssertEqual(iphone.rawValue, "iPhone 12 Pro Max")
     }
+    
+    // MARK: - Iphone 13 mini, 13, 13 Pro, 13 Pro Max
+    
+    func testIphone13MiniHasCorretName() {
+        let iphone: Device = .iphone13Mini
+        XCTAssertEqual(iphone.rawValue, "iPhone 13 mini")
+    }
+    
+    func testIphone13HasCorretName() {
+        let iphone: Device = .iphone13
+        XCTAssertEqual(iphone.rawValue, "iPhone 13")
+    }
+    
+    func testIphone13ProHasCorretName() {
+        let iphone: Device = .iphone13Pro
+        XCTAssertEqual(iphone.rawValue, "iPhone 13 Pro")
+    }
+    
+    func testIphone13ProMaxHasCorretName() {
+        let iphone: Device = .iphone13ProMax
+        XCTAssertEqual(iphone.rawValue, "iPhone 13 Pro Max")
+    }
 }

--- a/Tests/PreviewDeviceTests/DeviceWatchTests.swift
+++ b/Tests/PreviewDeviceTests/DeviceWatchTests.swift
@@ -81,6 +81,18 @@ final class DeviceWatchTests: XCTestCase {
         XCTAssertEqual(iphone.rawValue, "Apple Watch Series 6 - 44mm")
     }
     
+    // MARK: - Watch Series 7 41mm, 45mm
+    
+    func testWatchSeries7_41mmHasCorretName() {
+        let iphone: Device = .watchSeries7_41mm
+        XCTAssertEqual(iphone.rawValue, "Apple Watch Series 7 - 41mm")
+    }
+    
+    func testWatchSeries7_45mmHasCorretName() {
+        let iphone: Device = .watchSeries7_45mm
+        XCTAssertEqual(iphone.rawValue, "Apple Watch Series 7 - 45mm")
+    }
+    
     // MARK: - Watch SE 40mm, 44mm
     
     func testWatchSE_40mmHasCorretName() {


### PR DESCRIPTION
Add support new devices from xcode 13. Add unit tests for new devices. 
New devices:
- iPhone 13 mini, 13, 13Pro, 13Pro Max
- Apple Watch 7 41 mm, 44 mm
- iPad 9 Gen, iPad mini 6 gen